### PR TITLE
✨ feat: ChatArea 컴포넌트 구현

### DIFF
--- a/src/components/base/ChatArea/ChatArea.stories.tsx
+++ b/src/components/base/ChatArea/ChatArea.stories.tsx
@@ -18,8 +18,8 @@ const Template: ComponentStory<typeof ChatArea> = ({ error = false }) => {
   return (
     <Wrapper>
       <ChatArea
-        width={320}
-        height={20}
+        width="320px"
+        height="320px"
         name="ChatArea"
         value={value}
         isBottom={true}

--- a/src/components/base/ChatArea/ChatArea.stories.tsx
+++ b/src/components/base/ChatArea/ChatArea.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import ChatArea from './ChatArea';
 
@@ -7,28 +8,36 @@ export default {
   component: ChatArea,
 } as ComponentMeta<typeof ChatArea>;
 
-const Template: ComponentStory<typeof ChatArea> = (args) => (
-  <Wrapper>
-    <ChatArea {...args} />
-  </Wrapper>
-);
+const Template: ComponentStory<typeof ChatArea> = ({ error = false }) => {
+  const [value, setValue] = useState<string>('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <Wrapper>
+      <ChatArea
+        width={320}
+        height={20}
+        name="ChatArea"
+        value={value}
+        isBottom={true}
+        onChange={handleChange}
+        error={error}
+      />
+    </Wrapper>
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {
-  width: 320,
-  height: 20,
-  name: 'ChatArea',
   error: false,
-  isBottom: true,
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  width: 320,
-  height: 20,
-  name: 'ChatArea',
   error: true,
-  isBottom: true,
 };
 
 const Wrapper = styled.div`

--- a/src/components/base/ChatArea/ChatArea.stories.tsx
+++ b/src/components/base/ChatArea/ChatArea.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import styled from 'styled-components';
+import ChatArea from './ChatArea';
+
+export default {
+  title: 'base/ChatArea',
+  component: ChatArea,
+} as ComponentMeta<typeof ChatArea>;
+
+const Template: ComponentStory<typeof ChatArea> = (args) => (
+  <Wrapper>
+    <ChatArea {...args} />
+  </Wrapper>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  width: 320,
+  height: 20,
+  name: 'ChatArea',
+  error: false,
+  isBottom: true,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  width: 320,
+  height: 20,
+  name: 'ChatArea',
+  error: true,
+  isBottom: true,
+};
+
+const Wrapper = styled.div`
+  height: 320px;
+  position: relative;
+  border: 1px solid black;
+`;

--- a/src/components/base/ChatArea/ChatArea.tsx
+++ b/src/components/base/ChatArea/ChatArea.tsx
@@ -41,7 +41,6 @@ const ChatArea = ({
 
   const setNewSize = (): void => {
     if (areaRef.current) {
-      console.log(areaRef.current.scrollHeight);
       areaRef.current.style.height = '1px';
       areaRef.current.style.height = areaRef.current.scrollHeight + 'px';
     }

--- a/src/components/base/ChatArea/ChatArea.tsx
+++ b/src/components/base/ChatArea/ChatArea.tsx
@@ -1,0 +1,98 @@
+import { useRef } from 'react';
+import styled from 'styled-components';
+
+interface ChatAreaProps {
+  width: number;
+  height: number;
+  name: string;
+  value: string;
+  error: boolean;
+  isBottom: boolean;
+}
+
+const ChatArea = ({
+  width,
+  height,
+  name,
+  value,
+  error,
+  isBottom,
+  ...props
+}: ChatAreaProps) => {
+  const areaRef = useRef<HTMLTextAreaElement>(null);
+  let status: string = '';
+
+  if (error) {
+    status = 'error';
+  }
+
+  const ChatAreaStyle: React.CSSProperties = {
+    width: width,
+    height: height,
+  };
+
+  const BottomFixedStyle: React.CSSProperties | null = isBottom
+    ? {
+        position: 'absolute',
+        bottom: 0,
+      }
+    : // isBottom이 아닐때는 null 로 줘도 될까요? 혹은 type 정의에 '| null' 을 빼고 isBottom ? { ...적용할 스타일 } : {} 로 주는게 나을까요?
+      null;
+
+  const setNewSize = (): void => {
+    if (areaRef.current) {
+      console.log(areaRef.current.scrollHeight);
+      areaRef.current.style.height = '1px';
+      areaRef.current.style.height = areaRef.current.scrollHeight + 'px';
+    }
+  };
+
+  // 이 방법으로 onChange 없이 textarea의 높이를 추적하려고 했는데, [areaRef.current?.scrollHeight] 에서 높이 변화를 인식하지 못합니다.
+  // useEffect(() => {
+  //   if (areaRef.current) {
+  //     console.log(areaRef.current.scrollHeight);
+  //     areaRef.current.style.height = '1px';
+  //     areaRef.current.style.height = areaRef.current.scrollHeight + 'px';
+  //   }
+  // }, [areaRef.current?.scrollHeight]);
+
+  return (
+    <ChatAreaContainer
+      ref={areaRef}
+      value={value}
+      onChange={() => setNewSize()}
+      name={name}
+      className={status || undefined}
+      style={{ ...ChatAreaStyle, ...BottomFixedStyle }}
+      {...props}
+    />
+  );
+};
+
+const ChatAreaContainer = styled.textarea`
+  display: block;
+  box-sizing: border-box;
+  resize: none;
+  overflow-y: hidden;
+  border: none;
+  border-bottom: 1px solid #3e72f6;
+  outline: 0;
+  background: white;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #343434;
+  &::placeholder {
+    color: #8c8c8c;
+  }
+  &:disabled,
+  &:disabled:hover {
+    cursor: not-allowed;
+    background-color: #f3f3f3;
+    transition: none;
+  }
+  &.error {
+    border-color: #f53354;
+  }
+`;
+export default ChatArea;

--- a/src/components/base/ChatArea/ChatArea.tsx
+++ b/src/components/base/ChatArea/ChatArea.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 interface ChatAreaProps {
-  width: number;
-  height: number;
+  width: string;
+  height: string;
   name: string;
   value: string;
   error: boolean;
@@ -38,13 +38,6 @@ const ChatArea = ({
     bottom: 0,
   };
 
-  const handleOnChange = useCallback(
-    (e: React.ChangeEvent) => {
-      onChange(e);
-    },
-    [onChange],
-  );
-
   useEffect(() => {
     if (areaRef.current) {
       areaRef.current.style.height = '1px';
@@ -56,7 +49,7 @@ const ChatArea = ({
     <ChatAreaContainer
       ref={areaRef}
       value={value}
-      onChange={handleOnChange}
+      onChange={onChange}
       name={name}
       className={status || undefined}
       style={

--- a/src/components/base/ChatArea/ChatArea.tsx
+++ b/src/components/base/ChatArea/ChatArea.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 interface ChatAreaProps {
@@ -8,6 +8,7 @@ interface ChatAreaProps {
   value: string;
   error: boolean;
   isBottom: boolean;
+  onChange: React.ChangeEventHandler;
 }
 
 const ChatArea = ({
@@ -17,6 +18,7 @@ const ChatArea = ({
   value,
   error,
   isBottom,
+  onChange,
   ...props
 }: ChatAreaProps) => {
   const areaRef = useRef<HTMLTextAreaElement>(null);
@@ -31,38 +33,35 @@ const ChatArea = ({
     height: height,
   };
 
-  const BottomFixedStyle: React.CSSProperties | null = isBottom
-    ? {
-        position: 'absolute',
-        bottom: 0,
-      }
-    : // isBottom이 아닐때는 null 로 줘도 될까요? 혹은 type 정의에 '| null' 을 빼고 isBottom ? { ...적용할 스타일 } : {} 로 주는게 나을까요?
-      null;
+  const BottomFixedStyle: React.CSSProperties = {
+    position: 'absolute',
+    bottom: 0,
+  };
 
-  const setNewSize = (): void => {
+  const handleOnChange = useCallback(
+    (e: React.ChangeEvent) => {
+      onChange(e);
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
     if (areaRef.current) {
       areaRef.current.style.height = '1px';
       areaRef.current.style.height = areaRef.current.scrollHeight + 'px';
     }
-  };
-
-  // 이 방법으로 onChange 없이 textarea의 높이를 추적하려고 했는데, [areaRef.current?.scrollHeight] 에서 높이 변화를 인식하지 못합니다.
-  // useEffect(() => {
-  //   if (areaRef.current) {
-  //     console.log(areaRef.current.scrollHeight);
-  //     areaRef.current.style.height = '1px';
-  //     areaRef.current.style.height = areaRef.current.scrollHeight + 'px';
-  //   }
-  // }, [areaRef.current?.scrollHeight]);
+  }, [value]);
 
   return (
     <ChatAreaContainer
       ref={areaRef}
       value={value}
-      onChange={() => setNewSize()}
+      onChange={handleOnChange}
       name={name}
       className={status || undefined}
-      style={{ ...ChatAreaStyle, ...BottomFixedStyle }}
+      style={
+        isBottom ? { ...ChatAreaStyle, ...BottomFixedStyle } : ChatAreaStyle
+      }
       {...props}
     />
   );


### PR DESCRIPTION
## 📌 이슈
> closed #11
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- ChatArea 컴포넌트 구현 & 스토리북 작업

## 📝 요약
- 애매했던 사항을 주석으로 달아놨는데 좋은 방법이 있을지 확인 부탁드립니다!
- `isBottom = true` 는 아래에 붙여서 타이핑이 일어나 줄바꿈이 되면 맨 아래를 기준으로 위로만 채팅이 올라가도록 구현했습니다.
- 빠진 사항이 있다면 말씀해주세요!
- 스토리북의 상위요소에 div border를 넣어 확인하였습니다.
  - 하단과 딱 붙어있는 이유는 이 상위로 한번 감싸고 그 요소를 배치할 것이라고 예상했습니다.
- 첨부파일 색상은 검은색이 섞여있어서 감안해서 확인해주세요 ㅠㅠ

<!-- PR 내용 요약 -->

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
- 기본
<img width="331" alt="image" src="https://user-images.githubusercontent.com/71081893/153547429-f5a15b26-6eea-44a1-bef1-46aba5f2adf0.png">
- 줄바꿈
<img width="332" alt="image" src="https://user-images.githubusercontent.com/71081893/153547561-488faa4b-7961-46ed-8537-631f16a29a3a.png">
- 에러 
<img width="326" alt="image" src="https://user-images.githubusercontent.com/71081893/153547605-c1b42840-6ee8-4898-874d-f7a09e2b0e22.png">

