### PR TITLE
:sparkles: feat: Message domain 컴포넌트 구현

### DIFF
--- a/src/components/base/Icon/Icon.tsx
+++ b/src/components/base/Icon/Icon.tsx
@@ -27,11 +27,9 @@ const Icon = ({ name, size, onClick }: IconProps) => {
 };
 
 const StyledIcon = styled.button<IconProps>`
-  position: absolute;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10;
   overflow: hidden;
   transition: transform 0.2s ease-in-out;
   &:hover {

--- a/src/components/domain/Message/Message.stories.tsx
+++ b/src/components/domain/Message/Message.stories.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { INITIAL_MESSAGES } from '~constants/index';
+import Message from './Message';
+import { Modal } from '~components/domain';
+import useMessage from '~hooks/useMessage';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootStateType } from '~store/reducers';
+import { initMessage } from '~store/actions/message';
+
+export default {
+  title: 'domain/Message',
+  component: Message,
+  args: {
+    message: INITIAL_MESSAGES[1],
+  },
+} as ComponentMeta<typeof Message>;
+
+const Template: ComponentStory<typeof Message> = (args) => {
+  const {
+    handleClickDelete,
+    handleDelete,
+    handleReply,
+    handleClose,
+    isModalOpen,
+    modalContent,
+  } = useMessage();
+  return (
+    <>
+      <Message {...args} onReply={handleReply} onDelete={handleClickDelete} />
+      <Modal
+        width="50vw"
+        visible={isModalOpen}
+        onSubmit={handleDelete}
+        onClose={handleClose}
+      >
+        {modalContent}
+      </Modal>
+    </>
+  );
+};
+
+export const MyMessage = Template.bind({});
+MyMessage.args = {
+  me: true,
+};
+
+export const OthersMessage = Template.bind({});
+
+export const Messages = () => {
+  const {
+    handleClickDelete,
+    handleDelete,
+    handleReply,
+    handleClose,
+    isModalOpen,
+    modalContent,
+  } = useMessage();
+  const { messages } = useSelector((state: RootStateType) => state.messages);
+  const dispatch = useDispatch();
+  return (
+    <>
+      <button
+        style={{ border: '1px solid #999', padding: '0.5em 1em' }}
+        onClick={() => dispatch(initMessage())}
+      >
+        상태 RESET
+      </button>
+      {messages.map((message) => (
+        <Message
+          key={message.messageId}
+          message={message}
+          me={message.userName === 'hyo-choi'}
+          onReply={handleReply}
+          onDelete={handleClickDelete}
+        />
+      ))}
+      <Modal
+        width="30em"
+        visible={isModalOpen}
+        onSubmit={handleDelete}
+        onClose={handleClose}
+      >
+        {modalContent}
+      </Modal>
+    </>
+  );
+};

--- a/src/components/domain/Message/Message.stories.tsx
+++ b/src/components/domain/Message/Message.stories.tsx
@@ -12,7 +12,12 @@ export default {
   title: 'domain/Message',
   component: Message,
   args: {
-    message: INITIAL_MESSAGES[1],
+    message: {
+      ...INITIAL_MESSAGES[1],
+      messageId: 'this-is-not-redux-message',
+      content:
+        '이 메시지에는 일부러 유효하지 않은 messageId를 주어 redux와 연동하지 않았습니다. 따라서 삭제하셔도 삭제 동작을 확인할 수 없습니다. 동작을 확인하시려면 "Messages" story를 확인해주세요.',
+    },
   },
 } as ComponentMeta<typeof Message>;
 

--- a/src/components/domain/Message/Message.tsx
+++ b/src/components/domain/Message/Message.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Avatar, Icon } from '~components/base';
+import { COLORS } from '~constants/index';
+import { MessageType } from '~types/index';
+import { dateToFormattedString } from '~utils/index';
+
+interface MessageProps {
+  me?: boolean;
+  message: MessageType;
+  onReply: React.MouseEventHandler;
+  onDelete: React.MouseEventHandler;
+}
+
+const Message = ({ message, me = false, onReply, onDelete }: MessageProps) => {
+  const { messageId, userName, profileImage, content, date } = message;
+  return (
+    <Container me={me} data-message-id={messageId}>
+      <InnerContainer me={me}>
+        <AvatarContainer>
+          <Avatar src={profileImage} alt={`${userName} avatar`} />
+        </AvatarContainer>
+        <Wrapper>
+          <p>
+            <NameContainer>{`${me ? '*' : ''}${userName}`}</NameContainer>
+            <DateContainer>{dateToFormattedString(date)}</DateContainer>
+          </p>
+          <MessageContainer data-is-message={true}>{content}</MessageContainer>
+          <ButtonContainer>
+            <Icon name="reply" size={16} onClick={onReply} />
+            <Icon name="delete" size={12} onClick={onDelete} />
+          </ButtonContainer>
+        </Wrapper>
+      </InnerContainer>
+    </Container>
+  );
+};
+
+interface ContainerProps {
+  me: boolean;
+}
+
+const Container = styled.article<ContainerProps>`
+  display: flex;
+  justify-content: ${({ me }) => (me ? 'flex-end' : 'flex-start')};
+  align-items: center;
+  width: 100%;
+`;
+
+const InnerContainer = styled.div<ContainerProps>`
+  display: flex;
+  flex-direction: ${({ me }) => (me ? 'row-reverse' : 'row')};
+  justify-content: ${({ me }) => (me ? 'flex-end' : 'flex-start')};
+  gap: 0.5em;
+  align-items: flex-end;
+  width: 60%;
+
+  @media screen and (max-width: 767px) {
+    width: 80%;
+  }
+`;
+
+const AvatarContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2em;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  width: 100%;
+`;
+
+const NameContainer = styled.span`
+  margin-right: 1em;
+  font-weight: 500;
+  line-height: 1.4em;
+`;
+
+const DateContainer = styled.span`
+  color: #888;
+  line-height: 1.4em;
+  margin-right: 1em;
+`;
+
+const MessageContainer = styled.div`
+  width: 100%;
+  padding: 1.5em 1em;
+  background-color: ${COLORS.GREY};
+  border-radius: 15px;
+  word-break: break-all;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5em;
+  height: 2em;
+`;
+
+export default Message;

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { default as Modal } from './Modal/Modal';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export { INITIAL_USER, USER_HYOCHOI, USER_BRADGO, USER_KRUNGY } from './user';
 export { INITIAL_MESSAGES } from './message';
+export { COLORS } from './style';

--- a/src/hooks/useMessage.ts
+++ b/src/hooks/useMessage.ts
@@ -1,0 +1,54 @@
+import { useCallback, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootStateType } from '~store/reducers';
+import { closeModal, showModal } from '~store/actions/modal';
+import { deleteMessage } from '~store/actions/message';
+import { ellipsisString } from '~utils/message';
+
+const useMessage = () => {
+  const dispatch = useDispatch();
+  const state = useSelector((state: RootStateType) => state.modal);
+  const messageId = useRef('');
+  const [content, setContent] = useState<string>('');
+
+  const handleClickDelete = useCallback(
+    (e: React.MouseEvent) => {
+      const container: HTMLDivElement = (e.target as HTMLElement).closest(
+        '[data-message-id]',
+      )!;
+      const messageContainer: HTMLDivElement =
+        container.querySelector('[data-is-message]')!;
+      messageId.current = container.dataset.messageId!;
+      const message = messageContainer.innerText;
+      setContent(`${ellipsisString(message)} 메시지를 삭제하시겠습니까?`);
+      dispatch(showModal());
+    },
+    [dispatch],
+  );
+
+  const handleDelete = useCallback(() => {
+    dispatch(deleteMessage({ messageId: messageId.current }));
+    dispatch(closeModal());
+    messageId.current = '';
+  }, [dispatch]);
+
+  const handleReply = useCallback(() => {
+    // TODO: Message 상위 컴포넌트에서 구현 필요
+    console.log('Reply clicked');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    dispatch(closeModal());
+  }, [dispatch]);
+
+  return {
+    handleClickDelete,
+    handleDelete,
+    handleReply,
+    handleClose,
+    isModalOpen: state.showModal,
+    modalContent: content,
+  };
+};
+
+export default useMessage;

--- a/src/store/actions/message.ts
+++ b/src/store/actions/message.ts
@@ -6,9 +6,13 @@ import {
 } from '~store/actions/types';
 import type { MessageType } from '~types/index';
 
+interface DeleteType {
+  messageId: string;
+}
+
 export const initMessage = createAction(INIT_MESSAGES)();
 export const addMessage = createAction(ADD_MESSAGE)<MessageType>();
-export const deleteMessage = createAction(DELETE_MESSAGE)<MessageType>();
+export const deleteMessage = createAction(DELETE_MESSAGE)<DeleteType>();
 
 const actions = { initMessage, addMessage, deleteMessage };
 export type MessageActionType = ActionType<typeof actions>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { dateToFormattedString, ellipsisString } from './message';

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,0 +1,18 @@
+function addPrevZero(number: number): string {
+  return number < 10 ? `0${number}` : `${number}`;
+}
+
+export function dateToFormattedString(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = addPrevZero(date.getMonth() + 1);
+  const dd = addPrevZero(date.getDate());
+  const hh = addPrevZero(date.getHours());
+  const MM = addPrevZero(date.getMinutes());
+  const ss = addPrevZero(date.getSeconds());
+  return `${yyyy}-${mm}-${dd} ${hh}:${MM}:${ss}`;
+}
+
+export function ellipsisString(str: string) {
+  if (str.length <= 10) return str;
+  return `${str.substring(0, 10)}...`;
+}


### PR DESCRIPTION
## 📌 이슈
> closed #5

## 🛠 작업 사항

- [x] me props로 좌우 위치 조정
- [x] 프로필 이미지는 원형으로 왼쪽에 보입니다.
- [x] 오른쪽 컨텐츠 영역 상단에는 이름과 보낸 날짜 하단에는 보낸 메시지의 내용이 출력됩니다.
- [x] 메시지의 가장 오른쪽에는 삭제 버튼과 답장 버튼이 존재합니다.
- [x] 내가 전송한 메시지의 경우 이름 옆에 * 문자가 출력됩니다.
- [x] 보낸 날짜의 경우 yyyy-mm-dd hh:MM:ss 포멧으로 출력됩니다. (사용자의 시간대로 출력)

## 📝 요약

- message 컴포넌트를 구현했습니다.
- story를 작성하기 위해 useMessage custom hook을 구현했고, hook 내부 redux의 상태, action을 가져다 썼습니다.
 Messenger 컴포넌트에서 이 hook을 사용할 수 있지 않을까 싶습니다.
<!-- PR 내용 요약 -->

## 📸 첨부
![스크린샷, 2022-02-11 19-36-09](https://user-images.githubusercontent.com/57004991/153577028-4a103f17-5772-4811-9967-6c624fc59975.png)
